### PR TITLE
More informative mapping error

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -93,7 +93,7 @@ func (m fieldMap) getTraversals(names []string) [][]int {
 	for _, name := range names {
 		f, ok := m[name]
 		if !ok {
-			panic(fmt.Errorf("unable to find field %s", name))
+			panic(fmt.Errorf("db field '%s' has no mapping", name))
 		}
 		traversals = append(traversals, f.Index)
 	}


### PR DESCRIPTION
otherwise you get something like this:

--- FAIL: TestJobs (1.21s)
panic: unable to find field feed_sync_id [recovered]
	panic: unable to find field feed_sync_id

goroutine 7 [running]:
testing.func·006()
	/usr/local/go/src/testing/testing.go:441 +0x181
square/up/vendor/squalor.fieldMap.getTraversals(0xc2084ef7a0, 0xc20845cf00, 0x7, 0x8, 0x0, 0x0, 0x0)
	/Users/shawn/Development/go/src/square/up/vendor/squalor/reflect.go:96 +0x26c
square/up/vendor/squalor.makeGetPlan(0xc2084566c0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/shawn/Development/go/src/square/up/vendor/squalor/db.go:93 +0x30e
square/up/vendor/squalor.newModel(0x673ad28, 0x47b4ae0, 0x4853ff0, 0x6, 0xc2083a7f00, 0x7, 0x8, 0xc2084ef4a0, 0xc2084ef6e0, 0xc208502f40, ...)
	/Users/shawn/Development/go/src/square/up/vendor/squalor/db.go:224 +0x17c
square/up/vendor/squalor.(*DB).BindModel(0xc2083a7900, 0x4853ff0, 0x6, 0x47b4ae0, 0xc20824ff90, 0xc208456480, 0x0, 0x0)
	/Users/shawn/Development/go/src/square/up/vendor/squalor/db.go:336 +0x34d