### PR TITLE
Remove panic on unmapped field

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -15,7 +15,6 @@
 package squalor
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 )
@@ -91,11 +90,9 @@ func getDBFields(t reflect.Type) fieldMap {
 func (m fieldMap) getTraversals(names []string) [][]int {
 	var traversals [][]int
 	for _, name := range names {
-		f, ok := m[name]
-		if !ok {
-			panic(fmt.Errorf("db field '%s' has no mapping", name))
+		if f, ok := m[name]; ok {
+			traversals = append(traversals, f.Index)
 		}
-		traversals = append(traversals, f.Index)
 	}
 	return traversals
 }


### PR DESCRIPTION
For #11 

This panic makes rolling back after a migration impossible without undoing the migration. I think this was the source of a recent outage in a Square service, although I don't know the details.

Is there anything less dramatic we can do instead of panic?