### PR TITLE
Add DB.IgnoreUnmappedCols flag to avoid DB migration time errors

### DIFF
--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -56,7 +56,7 @@ func newTestStatementsDB(t *testing.T) *DB {
 			Columns: table.Columns[:len(table.Columns)-1],
 		}
 		modelT := reflect.TypeOf(d.model)
-		m, err := newModel(modelT, *table)
+		m, err := newModel(db, modelT, *table)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/db_test.go
+++ b/db_test.go
@@ -18,6 +18,7 @@ import (
 	"database/sql"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/coopernurse/gorp"
@@ -25,12 +26,28 @@ import (
 
 const objectsDDL = `
 CREATE TABLE objects (
-  user_id     BIGINT    NOT NULL,
+  user_id     BIGINT         NOT NULL,
   object_id   VARBINARY(767) NOT NULL,
   value       BLOB           NULL,
   timestamp   BIGINT         NULL,
   PRIMARY KEY (user_id, object_id),
   INDEX (user_id, timestamp)
+)`
+
+const objectsDDLWithUnmappedColumns = `
+CREATE TABLE objects (
+  user_id     BIGINT         NOT NULL,
+  object_id   VARBINARY(767) NOT NULL,
+  value       BLOB           NULL,
+  timestamp   BIGINT         NULL,
+  unmapped    VARBINARY(767) NULL,
+  PRIMARY KEY (user_id, object_id),
+  INDEX (user_id, timestamp)
+)`
+
+const objectsDDLAddUnmappedColumns = `
+ALTER TABLE objects ADD COLUMN (
+  unmapped VARBINARY(767) NULL
 )`
 
 const usersDDL = `
@@ -39,10 +56,22 @@ CREATE TABLE users (
   name VARCHAR(255) NOT NULL
 )`
 
-func TestDB(t *testing.T) {
+func TestDB_WithoutUnmappedColumns(t *testing.T) {
 	db := makeTestDB(t, objectsDDL)
 	defer db.Close()
 
+	testDB(db, t)
+}
+
+func TestDB_WithUnmappedColumnsIgnored(t *testing.T) {
+	db := makeTestDB(t, objectsDDLWithUnmappedColumns)
+	defer db.Close()
+	db.IgnoreUnmappedCols = true
+
+	testDB(db, t)
+}
+
+func testDB(db *DB, t *testing.T) {
 	type BaseModel struct {
 		UserID    int64  `db:"user_id"`
 		ID        string `db:"object_id"`
@@ -593,6 +622,80 @@ func TestDBAllowStringQueries(t *testing.T) {
 	// String queries should fail.
 	if err := db.Select(&results, "SELECT * FROM item"); err == nil {
 		t.Fatalf("Expected error, but found success")
+	}
+}
+
+func TestBindModel_FailUnknownColumns(t *testing.T) {
+	db := makeTestDB(t, objectsDDLWithUnmappedColumns)
+	defer db.Close()
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("Expected to recover an error")
+		}
+		str := "field 'unmapped' has no mapping"
+		if !strings.Contains(r.(error).Error(), str) {
+			t.Fatalf("Expected error to contain \"%s\", but got \"%s\"", str, r)
+		}
+	}()
+
+	db.BindModel("objects", Object{})
+	t.Fatal("Expected panic. Should not reach here")
+}
+
+func TestSelect_FailOnUnknownColumns(t *testing.T) {
+	db := makeTestDB(t, objectsDDL)
+	defer db.Close()
+
+	items, err := db.BindModel("objects", Object{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	i := &Object{UserID: 1, ID: "bar", Value: "hello world"}
+	if err := db.Insert(i); err != nil {
+		t.Fatal(err)
+	}
+
+	db.Exec(objectsDDLAddUnmappedColumns)
+
+	var results []Object
+	err = db.Select(&results, items.Select("*"))
+	if err == nil {
+		t.Fatalf("Expected error, but got %+v", results)
+	}
+	str := "unable to find mapping for column 'unmapped'"
+	if !strings.Contains(err.Error(), str) {
+		t.Fatalf("Expected error to contain \"%s\", but got \"%s\"", str, err)
+	}
+}
+
+func TestStructScan_FailOnUnknownColumns(t *testing.T) {
+	db := makeTestDB(t, objectsDDL)
+	defer db.Close()
+
+	items, err := db.BindModel("objects", Object{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	i := &Object{UserID: 1, ID: "bar", Value: "hello world"}
+	if err := db.Insert(i); err != nil {
+		t.Fatal(err)
+	}
+
+	db.Exec(objectsDDLAddUnmappedColumns)
+
+	j := &Object{}
+	q := items.Select("*").Where(items.C("user_id").Eq(1))
+	err = db.QueryRow(q).StructScan(j)
+	if err == nil {
+		t.Fatal("Expected error, but got %+v", j)
+	}
+	str := "unable to find mapping for column 'unmapped'"
+	if !strings.Contains(err.Error(), str) {
+		t.Fatalf("Expected error to contain \"%s\", but got \"%s\"", str, err)
 	}
 }
 

--- a/reflect.go
+++ b/reflect.go
@@ -100,6 +100,21 @@ func (m fieldMap) getTraversals(names []string) [][]int {
 	return traversals
 }
 
+func (m fieldMap) getMappedColumns(columns []*Column, ignoreUnmappedCols bool) []*Column {
+	var mappedColumns []*Column
+	for _, col := range columns {
+		_, ok := m[col.Name]
+		if !ok {
+			if !ignoreUnmappedCols {
+				panic(fmt.Errorf("db field '%s' has no mapping", col.Name))
+			}
+			continue
+		}
+		mappedColumns = append(mappedColumns, col)
+	}
+	return mappedColumns
+}
+
 // deref is Indirect for reflect.Type
 func deref(t reflect.Type) reflect.Type {
 	if t.Kind() == reflect.Ptr {


### PR DESCRIPTION
Add `DB.IgnoreUnmappedCols` flag that can be used to avoid DB migration time errors that occur at a few places when a column is not known to the previous version of binary. This change also makes it possible to deprecate and remove unused columns. The places an error could occur for unknown columns include `BindModel`, `Select`, `StructScan`, `Insert` and probably some others.

