### PR TITLE
Add Executor.Execute and QueryLogger

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,49 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package squalor
+
+import (
+	"log"
+	"time"
+)
+
+// QueryLogger defines an interface for query loggers.
+type QueryLogger interface {
+	// Log is called on completion of a query with a Serializer for the
+	// query, the Executor it was called on, the execution time of the query
+	// and an error if one occurred.
+	//
+	// The Executor may be used to trace queries within a transaction because
+	// queries in the same transaction will use the same executor.
+	Log(query Serializer, exec Executor, executionTime time.Duration, err error)
+}
+
+// StandardLogger implements the QueryLogger interface and wraps a log.Logger.
+type StandardLogger struct {
+	*log.Logger
+}
+
+func (l *StandardLogger) Log(query Serializer, exec Executor, executionTime time.Duration, err error) {
+	querystr, serializeErr := Serialize(query)
+	if serializeErr != nil {
+		return
+	}
+
+	if err != nil {
+		l.Printf("[%p] %s - `%s` - %s\n", exec, executionTime, querystr, err)
+	} else {
+		l.Printf("[%p] %s - `%s`\n", exec, executionTime, querystr)
+	}
+}


### PR DESCRIPTION
Not sure if this is the best approach... Also not sure if 'interpolation' is the correct word choice for substituting values into a SQL query.

My goal is to create something similar to gorp's [GorpLogger](https://github.com/go-gorp/gorp#sql-logging) but more powerful by allowing you to log only queries slower than some threshold. Since SQL queries often contain sensitive data, I wanted the ability to log queries without any values, which required a change to the Serializer interface.

I also added an Execute() method to the Executor interface so that if you build a query using a Delete/Update/Replace/etc. builder, you can pass it directly to Execute() without serializing it yourself. I believe you currently need to do:
```go
querystr, err := squalor.Serialize(builder)
if err != nil {
    // Handle error condition
}
results, err := db.Exec(querystr)
```
which is a little clunky.

@octavore @chriskillpack @tdeck @strangemonad 