### PR TITLE
Default IgnoreUnmappedCols to true

### DIFF
--- a/db.go
+++ b/db.go
@@ -276,7 +276,8 @@ type DB struct {
 	// errors at DB migration time when new columns are added but the previous version of the binary
 	// is still in use, either actively running or getting started up.
 	//
-	// The default is false.
+	// The default is true that ignores the unmapped columns.
+	// NOTE: Unmapped columns in primary keys are still not allowed.
 	IgnoreUnmappedCols bool
 	Logger             QueryLogger
 	mu                 sync.RWMutex
@@ -289,7 +290,7 @@ func NewDB(db *sql.DB) *DB {
 	return &DB{
 		DB:                 db,
 		AllowStringQueries: true,
-		IgnoreUnmappedCols: false,
+		IgnoreUnmappedCols: true,
 		Logger:             nil,
 		models:             map[reflect.Type]*Model{},
 		mappings:           map[reflect.Type]fieldMap{},

--- a/db_test.go
+++ b/db_test.go
@@ -66,7 +66,6 @@ func TestDB_WithoutUnmappedColumns(t *testing.T) {
 func TestDB_WithUnmappedColumnsIgnored(t *testing.T) {
 	db := makeTestDB(t, objectsDDLWithUnmappedColumns)
 	defer db.Close()
-	db.IgnoreUnmappedCols = true
 
 	testDB(db, t)
 }
@@ -627,6 +626,7 @@ func TestDBAllowStringQueries(t *testing.T) {
 
 func TestBindModel_FailUnknownColumns(t *testing.T) {
 	db := makeTestDB(t, objectsDDLWithUnmappedColumns)
+	db.IgnoreUnmappedCols = false
 	defer db.Close()
 
 	defer func() {
@@ -646,6 +646,7 @@ func TestBindModel_FailUnknownColumns(t *testing.T) {
 
 func TestSelect_FailOnUnknownColumns(t *testing.T) {
 	db := makeTestDB(t, objectsDDL)
+	db.IgnoreUnmappedCols = false
 	defer db.Close()
 
 	items, err := db.BindModel("objects", Object{})
@@ -673,6 +674,7 @@ func TestSelect_FailOnUnknownColumns(t *testing.T) {
 
 func TestStructScan_FailOnUnknownColumns(t *testing.T) {
 	db := makeTestDB(t, objectsDDL)
+	db.IgnoreUnmappedCols = false
 	defer db.Close()
 
 	items, err := db.BindModel("objects", Object{})


### PR DESCRIPTION
We ran into the same unmapped column issue for another service. Changing the default of `IgnoreUnmappedCols` to `true` since it's more needed behavior.

CC: @jbowens