### PR TITLE
db.Get() should pass a Serializer to QueryRow

### DIFF
--- a/db.go
+++ b/db.go
@@ -1151,18 +1151,13 @@ func getObject(db *DB, exec Executor, obj interface{}, keys []interface{}) error
 	}
 	q.Where(where)
 
-	s, err := Serialize(&q)
-	if err != nil {
-		return err
-	}
-
 	v := reflect.Indirect(reflect.ValueOf(obj))
 	dest := make([]interface{}, len(model.get.traversals))
 	for i, traversal := range model.get.traversals {
 		dest[i] = v.FieldByIndex(traversal).Addr().Interface()
 	}
 
-	if err := exec.QueryRow(s).Scan(dest...); err != nil {
+	if err := exec.QueryRow(&q).Scan(dest...); err != nil {
 		return err
 	}
 

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -112,7 +112,17 @@ func (r *recordingExecutor) QueryRow(query interface{}, args ...interface{}) *Ro
 	if len(args) != 0 {
 		panic(fmt.Errorf("expected 0 args: %+v", args))
 	}
-	r.query = append(r.query, query.(string))
+
+	if s, ok := query.(string); ok {
+		r.query = append(r.query, s)
+	} else if serializer, ok := query.(Serializer); ok {
+		s, err := Serialize(serializer)
+		if err != nil {
+			return &Row{err: err}
+		}
+		r.query = append(r.query, s)
+	}
+
 	return &Row{err: fmt.Errorf("ignored")}
 }
 


### PR DESCRIPTION
I missed one call site in #17. This will ensure that SerializeWithPlaceholders adds placeholders for queries going through `db.Get()`