### PR TITLE
Don't panic binding table without a primary key

### DIFF
--- a/db.go
+++ b/db.go
@@ -377,6 +377,10 @@ func (db *DB) BindModel(name string, obj interface{}) (*Model, error) {
 	if err != nil {
 		return nil, err
 	}
+	if table.PrimaryKey == nil {
+		return nil, fmt.Errorf("%s: table has no primary key", name)
+	}
+
 	m, err = newModel(db, t, *table)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
If you try to BindModel on a table without a primary key, you'll get a nil pointer panic.

@zhao-squareup @octavore