### PR TITLE
Allowing type aliases to be used as arguments

### DIFF
--- a/args.go
+++ b/args.go
@@ -1,0 +1,114 @@
+// Copyright 2015 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package squalor
+
+import (
+	"fmt"
+	"reflect"
+)
+
+var baseTypes = map[reflect.Type]bool{
+	reflect.TypeOf(new(bool)):    true,
+	reflect.TypeOf(new(int)):     true,
+	reflect.TypeOf(new(int8)):    true,
+	reflect.TypeOf(new(int16)):   true,
+	reflect.TypeOf(new(int32)):   true,
+	reflect.TypeOf(new(int64)):   true,
+	reflect.TypeOf(new(uint)):    true,
+	reflect.TypeOf(new(uint8)):   true,
+	reflect.TypeOf(new(uint16)):  true,
+	reflect.TypeOf(new(uint32)):  true,
+	reflect.TypeOf(new(uint64)):  true,
+	reflect.TypeOf(new(float32)): true,
+	reflect.TypeOf(new(float64)): true,
+	reflect.TypeOf(new(string)):  true,
+}
+
+var baseKinds = map[reflect.Kind]bool{
+	reflect.Bool:    true,
+	reflect.Int:     true,
+	reflect.Int8:    true,
+	reflect.Int16:   true,
+	reflect.Int32:   true,
+	reflect.Int64:   true,
+	reflect.Uint:    true,
+	reflect.Uint8:   true,
+	reflect.Uint16:  true,
+	reflect.Uint32:  true,
+	reflect.Uint64:  true,
+	reflect.Float32: true,
+	reflect.Float64: true,
+	reflect.String:  true,
+}
+
+func argsConvert(from []interface{}) []interface{} {
+	to := make([]interface{}, len(from))
+	for i, arg := range from {
+		value := reflect.ValueOf(arg)
+		if _, ok := baseTypes[value.Type()]; ok {
+			// Base type, let it through unchanged.
+			to[i] = arg
+		} else if _, ok := baseKinds[value.Kind()]; ok {
+			// Type alias, convert to base type.
+			to[i] = asKind(value)
+		} else {
+			// Other, deferring to lower-level libraries, and will likely result in a
+			// conversion error at the database/sql layer.
+			to[i] = arg
+		}
+	}
+	return to
+}
+
+func asKind(value reflect.Value) interface{} {
+	kind := value.Kind()
+	switch kind {
+	case reflect.Bool:
+		return value.Bool()
+
+	case reflect.Int:
+		fallthrough
+	case reflect.Int8:
+		fallthrough
+	case reflect.Int16:
+		fallthrough
+	case reflect.Int32:
+		fallthrough
+	case reflect.Int64:
+		return value.Int()
+
+	case reflect.Uint:
+		fallthrough
+	case reflect.Uint8:
+		fallthrough
+	case reflect.Uint16:
+		fallthrough
+	case reflect.Uint32:
+		fallthrough
+	case reflect.Uint64:
+		return value.Uint()
+
+	case reflect.Float32:
+		fallthrough
+	case reflect.Float64:
+		return value.Float()
+
+	case reflect.String:
+		return value.String()
+
+	default:
+		panic(fmt.Sprintf("unmapped base kind %s", kind))
+	}
+}

--- a/db.go
+++ b/db.go
@@ -450,7 +450,8 @@ func (db *DB) Exec(query interface{}, args ...interface{}) (sql.Result, error) {
 	}
 
 	start := time.Now()
-	result, err := db.DB.Exec(querystr, args...)
+	argsConverted := argsConvert(args)
+	result, err := db.DB.Exec(querystr, argsConverted...)
 	db.logQuery(serializer, db, start, err)
 
 	return result, err
@@ -495,7 +496,8 @@ func (db *DB) Query(query interface{}, args ...interface{}) (*Rows, error) {
 	}
 
 	start := time.Now()
-	rows, err := db.DB.Query(querystr, args...)
+	argsConverted := argsConvert(args)
+	rows, err := db.DB.Query(querystr, argsConverted...)
 	db.logQuery(serializer, db, start, err)
 
 	if err != nil {
@@ -519,7 +521,8 @@ func (db *DB) QueryRow(query interface{}, args ...interface{}) *Row {
 	}
 
 	start := time.Now()
-	rows, err := db.DB.Query(querystr, args...)
+	argsConverted := argsConvert(args)
+	rows, err := db.DB.Query(querystr, argsConverted...)
 	db.logQuery(serializer, db, start, err)
 
 	return &Row{rows: Rows{Rows: rows, db: db}, err: err}
@@ -636,7 +639,8 @@ func (tx *Tx) Exec(query interface{}, args ...interface{}) (sql.Result, error) {
 	}
 
 	start := time.Now()
-	result, err := tx.Tx.Exec(querystr, args...)
+	argsConverted := argsConvert(args)
+	result, err := tx.Tx.Exec(querystr, argsConverted...)
 	tx.DB.logQuery(serializer, tx, start, err)
 
 	return result, err
@@ -693,7 +697,8 @@ func (tx *Tx) Query(query interface{}, args ...interface{}) (*Rows, error) {
 	}
 
 	start := time.Now()
-	rows, err := tx.Tx.Query(querystr, args...)
+	argsConverted := argsConvert(args)
+	rows, err := tx.Tx.Query(querystr, argsConverted...)
 	tx.DB.logQuery(serializer, tx, start, err)
 
 	if err != nil {
@@ -717,7 +722,8 @@ func (tx *Tx) QueryRow(query interface{}, args ...interface{}) *Row {
 	}
 
 	start := time.Now()
-	rows, err := tx.Tx.Query(querystr, args...)
+	argsConverted := argsConvert(args)
+	rows, err := tx.Tx.Query(querystr, argsConverted...)
 	tx.DB.logQuery(serializer, tx, start, err)
 
 	return &Row{rows: Rows{Rows: rows, db: tx.DB}, err: err}

--- a/db_test.go
+++ b/db_test.go
@@ -774,6 +774,93 @@ func TestCommitHooks_PreFails(t *testing.T) {
 	}
 }
 
+type someTypeAlias string
+
+type someDoublyTypedAlias someTypeAlias
+
+func TestTypeAlias(t *testing.T) {
+	db := makeTestDB(t, usersDDL)
+	defer db.Close()
+
+	if _, err := db.BindModel("users", User{}); err != nil {
+		t.Fatal(err)
+	}
+	e := &User{ID: 0, Name: "foo"}
+	if err := db.Insert(e); err != nil {
+		t.Fatal(err)
+	}
+
+	// Count using plain old string type
+	count := func(name string) int {
+		var c []int
+		if err := db.Select(&c, "SELECT COUNT(*) FROM users WHERE name = ?", name); err != nil {
+			t.Fatal(err)
+		}
+		return c[0]
+	}
+
+	if count("foo") != 1 {
+		t.Fatalf("should start with one user, named 'foo'")
+	}
+
+	// Exec
+	if _, err := db.Exec("UPDATE users SET name = ?", someTypeAlias("bar")); err != nil {
+		t.Fatalf("failed querying with someTypeAlias: %s", err)
+	}
+
+	if count("bar") != 1 {
+		t.Fatalf("we should have renamed the user to 'bar'")
+	}
+
+	if _, err := db.Exec("UPDATE users SET name = ?", someDoublyTypedAlias("baz")); err != nil {
+		t.Fatalf("failed querying with someTypeAlias: %s", err)
+	}
+
+	if count("baz") != 1 {
+		t.Fatalf("we should have renamed the user to 'baz'")
+	}
+
+	// Select
+	var c []int
+	if err := db.Select(&c, "SELECT COUNT(*) FROM users WHERE name = ?", someTypeAlias("baz")); err != nil {
+		t.Fatal(err)
+	}
+	if c[0] != 1 {
+		t.Fatalf("we should have renamed the user to 'baz', and still find it")
+	}
+
+	// Query
+	row, err := db.Query("SELECT name FROM users WHERE name = ?", someTypeAlias("baz"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !row.Next() {
+		t.Fatal("there should be one row to read")
+	}
+	var name string
+	if err := row.Scan(&name); err != nil {
+		t.Fatal(err)
+	}
+	if name != "baz" {
+		t.Fatalf("we should have renamed the user to 'baz', and still be able to query it")
+	}
+	if err := row.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// QueryRow
+	rowPtr := db.QueryRow("SELECT name FROM users WHERE name = ?", someTypeAlias("baz"))
+	if rowPtr == nil {
+		t.Fatal("there should be one row to read")
+	}
+	if err := rowPtr.Scan(&name); err != nil {
+		t.Fatal(err)
+	}
+	if name != "baz" {
+		t.Fatalf("we should have renamed the user to 'baz', and still be able to query it")
+	}
+}
+
 type Object struct {
 	UserID    int64  `db:"user_id"`
 	ID        string `db:"object_id"`


### PR DESCRIPTION
We can now use type aliases such as

    type token string

and then query using `token("foo")`.