### PR TITLE
Adding exec.SelectOne

### DIFF
--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -199,7 +199,7 @@ func TestDBGetStatements(t *testing.T) {
 
 	for _, c := range testCases {
 		recorder := &recordingExecutor{DB: db}
-		if err := getObject(db, recorder, c.obj, c.keys); err == nil {
+		if err := getObjectByKeys(db, recorder, c.obj, c.keys); err == nil {
 			t.Fatalf("Expected ignored error, but found success")
 		}
 		if !reflect.DeepEqual([]string{c.expected}, recorder.query) {

--- a/db_test.go
+++ b/db_test.go
@@ -994,6 +994,26 @@ func TestTypeAlias_inMappedStruct(t *testing.T) {
 	}
 }
 
+func TestSelectOne(t *testing.T) {
+	db := makeTestDB(t, usersDDL)
+	defer db.Close()
+
+	if _, err := db.BindModel("users", User{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Insert(&User{Name: "one"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var user User
+	if err := db.SelectOne(&user, "SELECT * FROM users WHERE name = ?", "one"); err != nil {
+		t.Fatal(err)
+	}
+	if user.Name != "one" {
+		t.Errorf("expected name 'one', was '%s'", user.Name)
+	}
+}
+
 type Object struct {
 	UserID    int64  `db:"user_id"`
 	ID        string `db:"object_id"`


### PR DESCRIPTION
Convenience method to select a single row into a struct, similar to exec.Get but generalized to allow a query (with arguments).

cc @petermattis, @jbowens 