### PR TITLE
Detecting missing columns and failing model binding

### DIFF
--- a/db.go
+++ b/db.go
@@ -222,7 +222,11 @@ func newModel(db *DB, t reflect.Type, table Table) (*Model, error) {
 		Table:  table,
 		fields: getDBFields(t),
 	}
-	m.mappedColumns = m.fields.getMappedColumns(m.Columns, db.IgnoreUnmappedCols, db.IgnoreMissingCols)
+	mappedColumns, err := m.fields.getMappedColumns(m.Columns, db.IgnoreUnmappedCols, db.IgnoreMissingCols)
+	if err != nil {
+		panic(fmt.Errorf("%s: %s", table.Name, err))
+	}
+	m.mappedColumns = mappedColumns
 	m.mappedColNames = getColumnNames(m.mappedColumns)
 	m.delete = makeDeletePlan(m)
 	m.get = makeGetPlan(m)

--- a/reflect.go
+++ b/reflect.go
@@ -100,14 +100,14 @@ func (m fieldMap) getTraversals(names []string) [][]int {
 	return traversals
 }
 
-func (m fieldMap) getMappedColumns(columns []*Column, ignoreUnmappedCols, ignoreMissingCols bool) []*Column {
+func (m fieldMap) getMappedColumns(columns []*Column, ignoreUnmappedCols, ignoreMissingCols bool) ([]*Column, error) {
 	mapped := make(map[string]bool)
 	var mappedColumns []*Column
 	for _, col := range columns {
 		_, ok := m[col.Name]
 		if !ok {
 			if !ignoreUnmappedCols {
-				panic(fmt.Errorf("db field '%s' has no mapping", col.Name))
+				return nil, fmt.Errorf("db field '%s' has no mapping", col.Name)
 			}
 			continue
 		}
@@ -121,9 +121,9 @@ func (m fieldMap) getMappedColumns(columns []*Column, ignoreUnmappedCols, ignore
 				notMapped = append(notMapped, name)
 			}
 		}
-		panic(fmt.Errorf("model fields '%s' have no corresponding db field", strings.Join(notMapped, ", ")))
+		return nil, fmt.Errorf("model fields '%s' have no corresponding db field", strings.Join(notMapped, ", "))
 	}
-	return mappedColumns
+	return mappedColumns, nil
 }
 
 // deref is Indirect for reflect.Type

--- a/reflect.go
+++ b/reflect.go
@@ -100,7 +100,8 @@ func (m fieldMap) getTraversals(names []string) [][]int {
 	return traversals
 }
 
-func (m fieldMap) getMappedColumns(columns []*Column, ignoreUnmappedCols bool) []*Column {
+func (m fieldMap) getMappedColumns(columns []*Column, ignoreUnmappedCols, ignoreMissingCols bool) []*Column {
+	mapped := make(map[string]bool)
 	var mappedColumns []*Column
 	for _, col := range columns {
 		_, ok := m[col.Name]
@@ -111,6 +112,16 @@ func (m fieldMap) getMappedColumns(columns []*Column, ignoreUnmappedCols bool) [
 			continue
 		}
 		mappedColumns = append(mappedColumns, col)
+		mapped[col.Name] = true
+	}
+	if !ignoreMissingCols && len(mapped) != len(m) {
+		var notMapped []string
+		for name, _ := range m {
+			if !mapped[name] {
+				notMapped = append(notMapped, name)
+			}
+		}
+		panic(fmt.Errorf("model fields '%s' have no corresponding db field", strings.Join(notMapped, ", ")))
 	}
 	return mappedColumns
 }


### PR DESCRIPTION
Until now, missing columns which could be omitted in various statements (e.g. insert into a column with a default value) would silently function, with unexpected results such as failing to save data to the DB.

(Also making the panic message appear with the table name for simpler debugging.)