### PR TITLE
Allow an x/net/context to be passed to a QueryLogger

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -41,6 +41,20 @@ func (l *StandardLogger) Log(query Serializer, exec Executor, executionTime time
 		return
 	}
 
+	// The caller of the query can set a Context object on the database or transaction prior to
+	// issuing the query using the WithContext function, for example:
+	//
+	// tx.WithContext(context.WithValue(ctx, "user_id", userId).Query(...)
+	//
+	// The Context may be obtained inside this function by checking whether the Executor
+	// implements the ExecutorContext interface, and if so calling GetContext on it, for example:
+	//
+	// var userId interface{} = "<unknown>"
+	// if execContext, ok := exec.(ExecutorContext); ok {
+	// 	userId = execContext.GetContext().Value("user_id")
+	// }
+	// l.Printf("[%p] [user_id=%v] %s - `%s` - %s\n", exec, userId, executionTime, querystr, err)
+
 	if err != nil {
 		l.Printf("[%p] %s - `%s` - %s\n", exec, executionTime, querystr, err)
 	} else {


### PR DESCRIPTION
Sometimes we use a `context.Context` object to hold information that is useful for logging. Suppose we have a function `extractUserId(context.Context)` that retrieves the requestor's id from the context. Consider a simple function that runs a `squalor` query:

```
func runMyQuery(ctx context.Context, query string) {
  glog.Infof("Running query for user %s", extractUserId(ctx))
  myExecutor.Query(query)
}
```

We would like for the query logging mechanism to have access to `ctx` so it can also extract the user id from the context, allowing us to correlate the resulting log lines.

This patch allows us to pass a `Context` into the `Executor` using a new `WithContext` function:

```
func runMyQuery(ctx context.Context, query string) {
  glog.Infof("Running query for user %s", extractUserId(ctx))
  myExecutor.WithContext(ctx).Query(query)
}
```

```
func (l *MyQueryLogger) Log(query squalor.Serializer, exec squalor.Executor, executionTime time.Duration, queryErr error) {
  var userId interface{} = "<unknown>"
  if execContext, ok := exec.(ExecutorContext); ok {
    userId = extractUserId(execContext.GetContext())
  }
  glog.Infof("Ran query %v for user %s in %d ms", squalor.SerializeWithPlaceholders(query), userId, int64(executionTime/time.Millisecond))
}
```
This PR adds a new interface `ExecutorContext` that extends `Executor` with new functions `WithContext` and `GetContext`. Calling `db.WithContext(ctx)` or `tx.WithContext(ctx)` will not affect the original `DB` or `Tx` instance, but will instead return a copy containing the supplied `Context`.
