### PR TITLE
Issue 44: support for optimistic locking

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -178,6 +178,23 @@ See the documentation for DB.Delete for performance limitations when
 batch deleting multiple rows from a table with a primary key composed
 of multiple columns.
 
+Optimistic Locking
+
+To support optimistic locking with a column storing the version number,
+one field in a model object can be marked to serve as the lock. Modifying
+the example above:
+
+    type User struct {
+      ID   int64  `db:"id"`
+      Name string `db:"name"`
+      Ver  int    `db:"version,optlock"`
+    }
+
+Now, the Update method will ensure that the object has not been concurrently
+modified when writing, by constraining the update by the version number.
+If the update is successful, the version number will be both incremented
+on the model (in-memory), as well as in the database.
+
 Programmatic SQL Construction
 
 Programmatic construction of SQL queries prohibits SQL injection

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -35,7 +35,7 @@ func TestBasic(t *testing.T) {
 
 	f := Foo{1, 2, 3}
 	fv := reflect.ValueOf(f)
-	m := getMapping(reflect.TypeOf(f), "", nil)
+	m := getMapping(reflect.TypeOf(f), nil)
 
 	v := fieldByName(m, fv, "A")
 	if v.Int() != f.A {
@@ -71,7 +71,7 @@ func TestEmbedded(t *testing.T) {
 	z.B = 2
 	z.Bar.Foo.A = 3
 	zv := reflect.ValueOf(z)
-	m := getMapping(reflect.TypeOf(z), "", nil)
+	m := getMapping(reflect.TypeOf(z), nil)
 
 	v := fieldByName(m, zv, "A")
 	if v.Int() != z.A {
@@ -98,7 +98,7 @@ func TestPrivate(t *testing.T) {
 	z.B = 2
 	zv := reflect.ValueOf(z)
 
-	m := getMapping(reflect.TypeOf(z), "", nil)
+	m := getMapping(reflect.TypeOf(z), nil)
 
 	v := fieldByName(m, zv, "A")
 	if v.Int() != z.A {
@@ -153,6 +153,31 @@ func TestMapping(t *testing.T) {
 
 	if _, ok := m["ignored"]; ok {
 		t.Errorf("Expected to ignore `Ignored` field")
+	}
+}
+
+func TestReadTag(t *testing.T) {
+	testCases := []struct {
+		tag     string
+		name    string
+		optlock bool
+	}{
+		{"-", "-", false},
+		{"foo", "foo", false},
+		{"foo,", "foo", false},
+		{"foo,optlock", "foo", true},
+		{",optlock", "", true},
+		{",wrong", "", false},
+		{",", "", false},
+	}
+	for _, c := range testCases {
+		name, optlock := readTag(c.tag)
+		if name != c.name {
+			t.Errorf("%s: expected name '%s', actual '%s'", c.tag, c.name, name)
+		}
+		if optlock != c.optlock {
+			t.Errorf("%s: expected optlock '%t', actual '%t'", c.tag, c.optlock, optlock)
+		}
 	}
 }
 


### PR DESCRIPTION
Adding support for optimistic locking:

- One field on a model can be marked by `optlock`.
- Upon `Update`, squalor constrains the update statement by specifying the specific version and updates the version in the database,
- And checks that one and only one row is modified.
- If not, a concurrent modification is detected, and error thrown.
- Otherwise, the update is allowed and the version field (in-memory) is incremented.

Implementation required a few changes. First when binding models:

- When reading `db` tags, we check whether one is marked with `optlock` and record this.
- Then, when constructing the `Model` object, we can adjust the update plan used

And on `Update`:

- We use the update plan in close to the same manner
- Except that when choosing what to update the columns by, we use the expression `v = v + 1` for the version column
- And after the update statement is executed, we do concurrent modification detection (based on row count),
- And upon success, increment the in-memory model