### PR TITLE
Add support for context version of database/sql interface

### DIFF
--- a/db.go
+++ b/db.go
@@ -352,8 +352,8 @@ type DB struct {
 	// The default is true that ignores the unmapped columns.
 	// NOTE: Unmapped columns in primary keys are still not allowed.
 	IgnoreUnmappedCols bool
-	Context            context.Context
 	Logger             QueryLogger
+	context            context.Context
 	mu                 sync.RWMutex
 	models             map[reflect.Type]*Model
 	mappings           map[reflect.Type]fieldMap
@@ -426,8 +426,8 @@ func NewDB(db *sql.DB, options ...DBOption) (*DB, error) {
 		AllowStringQueries:    true,
 		IgnoreUnmappedCols:    true,
 		IgnoreMissingCols:     false,
-		Context:               context.Background(),
 		Logger:                nil,
+		context:               context.Background(),
 		deadlineQueryRewriter: noopDeadlineQueryRewriter,
 		models:                map[reflect.Type]*Model{},
 		mappings:              map[reflect.Type]fieldMap{},
@@ -586,12 +586,12 @@ func (db *DB) WithContext(ctx context.Context) ExecutorContext {
 		panic(fmt.Errorf("Nil Context passed to Executor.WithContext"))
 	}
 	newDB := *db
-	newDB.Context = ctx
+	newDB.context = ctx
 	return &newDB
 }
 
 func (db *DB) GetContext() context.Context {
-	return db.Context
+	return db.context
 }
 
 // Delete runs a batched SQL DELETE statement, grouping the objects by
@@ -677,8 +677,8 @@ func (db *DB) Insert(list ...interface{}) error {
 // instead.
 func (db *DB) Query(query interface{}, args ...interface{}) (*Rows, error) {
 	start := time.Now()
-	if db.Context != nil {
-		if deadline, ok := db.Context.Deadline(); ok && !deadline.IsZero() {
+	if db.context != nil {
+		if deadline, ok := db.context.Deadline(); ok && !deadline.IsZero() {
 			// Set an execution deadline for the query.
 			remainingMillis := int64(deadline.Sub(start) / time.Millisecond)
 			if remainingMillis > 0 {
@@ -838,7 +838,7 @@ func (tx *Tx) WithContext(ctx context.Context) ExecutorContext {
 	}
 	newTx := *tx
 	newDB := *newTx.DB
-	newDB.Context = ctx
+	newDB.context = ctx
 	newTx.DB = &newDB
 	return &newTx
 }
@@ -909,8 +909,8 @@ func (tx *Tx) Insert(list ...interface{}) error {
 // instead.
 func (tx *Tx) Query(query interface{}, args ...interface{}) (*Rows, error) {
 	start := time.Now()
-	if tx.DB.Context != nil {
-		if deadline, ok := tx.DB.Context.Deadline(); ok && !deadline.IsZero() {
+	if tx.DB.context != nil {
+		if deadline, ok := tx.DB.context.Deadline(); ok && !deadline.IsZero() {
 			// Set an execution deadline for the query.
 			remainingMillis := int64(deadline.Sub(start) / time.Millisecond)
 			if remainingMillis > 0 {

--- a/db_go17.go
+++ b/db_go17.go
@@ -1,0 +1,42 @@
+// Copyright 2017 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !go1.8
+
+package squalor
+
+import (
+	"database/sql"
+
+	"golang.org/x/net/context"
+)
+
+// executor exposes the sql.DB and sql.Tx functions so that it can be used
+// on internal functions that need to be agnostic to the underlying object.
+type executor interface {
+	Exec(query string, args ...interface{}) (sql.Result, error)
+	Query(query string, args ...interface{}) (*sql.Rows, error)
+}
+
+func exec(_ context.Context, ex executor, query string, args ...interface{}) (sql.Result, error) {
+	return ex.Exec(query, args...)
+}
+
+func query(_ context.Context, ex executor, query string, args ...interface{}) (*sql.Rows, error) {
+	return ex.Query(query, args...)
+}
+
+func begin(db *DB) (*sql.Tx, error) {
+	return db.DB.Begin()
+}

--- a/db_go18.go
+++ b/db_go18.go
@@ -1,0 +1,41 @@
+// Copyright 2017 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build go1.8
+
+package squalor
+
+import (
+	"context"
+	"database/sql"
+)
+
+// executor exposes the sql.DB and sql.Tx functions so that it can be used
+// on internal functions that need to be agnostic to the underlying object.
+type executor interface {
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
+}
+
+func exec(ctx context.Context, ex executor, query string, args ...interface{}) (sql.Result, error) {
+	return ex.ExecContext(ctx, query, args...)
+}
+
+func query(ctx context.Context, ex executor, query string, args ...interface{}) (*sql.Rows, error) {
+	return ex.QueryContext(ctx, query, args...)
+}
+
+func begin(db *DB) (*sql.Tx, error) {
+	return db.DB.BeginTx(db.context, nil)
+}

--- a/db_go18_test.go
+++ b/db_go18_test.go
@@ -1,0 +1,67 @@
+// Copyright 2017 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build go1.8
+
+package squalor
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestWithContextTimeout(t *testing.T) {
+	db := makeTestDB(t, usersDDL)
+	defer db.Close()
+
+	if db.GetContext() == nil {
+		t.Fatal("Expected default non-nil Context on DB")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	db = db.WithContext(ctx).(*DB)
+
+	// This query should be canceled.
+	if _, err := db.Query("SELECT SLEEP(1)"); err != context.DeadlineExceeded {
+		t.Fatalf("expected context.DeadlineExceeded, got %v", err)
+	}
+
+	// This query should immediately err because the context has already exceeded
+	// the timeout.
+	if _, err := db.Query("SELECT 1"); err != context.DeadlineExceeded {
+		t.Fatalf("expected context.DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestWithContextNoTimeout(t *testing.T) {
+	db := makeTestDB(t, usersDDL)
+	defer db.Close()
+
+	if db.GetContext() == nil {
+		t.Fatal("Expected default non-nil Context on DB")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	db = db.WithContext(ctx).(*DB)
+
+	// This query should not err.
+	if _, err := db.Query("SELECT 1"); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
The context API was introduced in Go 1.8 and allows for things like tracing (e.g., with Datadog) and query timeouts at the driver level. Note that the server-side query deadlines are still a configurable option; this provides an alternate mechanism via contexts.