### PR TITLE
Implement Serialize on Subquery

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -1157,6 +1157,22 @@ type Subquery struct {
 	Select SelectStatement
 }
 
+func (s *Subquery) Serialize(w Writer) error {
+	_, err := w.Write([]byte{'('})
+	if err != nil {
+		return err
+	}
+	err = s.Select.Serialize(w)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write([]byte{')'})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // BinaryExpr represents a binary value expression.
 type BinaryExpr struct {
 	Operator    byte

--- a/builder.go
+++ b/builder.go
@@ -588,9 +588,11 @@ func (b ValExprBuilder) In(list ...interface{}) BoolExprBuilder {
 }
 
 // InTuple creates an IN expression from a tuple.
-func (b ValExprBuilder) InTuple(tuple ValTuple) BoolExprBuilder {
-	if len(tuple.Exprs) == 0 {
-		return b.makeComparisonExpr(astIn, makeErrVal("empty list"))
+func (b ValExprBuilder) InTuple(tuple Tuple) BoolExprBuilder {
+	if valTuple, ok := tuple.(ValTuple); ok {
+		if len(valTuple.Exprs) == 0 {
+			return b.makeComparisonExpr(astIn, makeErrVal("empty list"))
+		}
 	}
 	return b.makeComparisonExpr(astIn, tuple)
 }
@@ -601,9 +603,11 @@ func (b ValExprBuilder) NotIn(list ...interface{}) BoolExprBuilder {
 }
 
 // NotInTuple creates a NOT IN expression from a tuple.
-func (b ValExprBuilder) NotInTuple(tuple ValTuple) BoolExprBuilder {
-	if len(tuple.Exprs) == 0 {
-		return b.makeComparisonExpr(astNotIn, makeErrVal("empty list"))
+func (b ValExprBuilder) NotInTuple(tuple Tuple) BoolExprBuilder {
+	if valTuple, ok := tuple.(ValTuple); ok {
+		if len(valTuple.Exprs) == 0 {
+			return b.makeComparisonExpr(astNotIn, makeErrVal("empty list"))
+		}
 	}
 	return b.makeComparisonExpr(astNotIn, tuple)
 }

--- a/builder_test.go
+++ b/builder_test.go
@@ -430,6 +430,8 @@ func TestSelectBuilder(t *testing.T) {
 			"SELECT * FROM `users` LEFT JOIN `objects`"},
 		{users.RightJoin(objects).Select("*"),
 			"SELECT * FROM `users` RIGHT JOIN `objects`"},
+		{users.Select("*").Where(foo.InTuple(&Subquery{objects.Select(objects.C("foo")).Where(objects.C("foo").Gt(10))})),
+			"SELECT * FROM `users` WHERE `users`.`foo` IN (SELECT `objects`.`foo` FROM `objects` WHERE `objects`.`foo` > 10)"},
 	}
 
 	for _, c := range testCases {


### PR DESCRIPTION
The Subquery struct cannot currently be used as any of the types that it otherwise implements (such as Tuple) because it does not implement Serialize.
I have implemented Serialize for Subquery, and I have modified InTuple and NotInTuple to accept the Tuple interface instead of the ValTuple struct.