### PR TITLE
Upgrading to CircleCI 2.0 and disabling strict mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,25 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.9.3
+      - image: circleci/mysql:5.6
+
+    working_directory: /go/src/github.com/square/squalor
+    steps:
+      - checkout
+      - run: go get -v -t -d ./...
+      - run:
+          name: Waiting for MySQL to be ready
+          command: |
+            for i in `seq 1 10`;
+            do
+              nc -z localhost 3306 && echo Success && exit 0
+              echo -n .
+              sleep 1
+            done
+            echo Failed waiting for MySQL && exit 1
+
+      - run:
+          name: Run Tests
+          command: go test -v -race ./...

--- a/base_test.go
+++ b/base_test.go
@@ -41,7 +41,7 @@ func makeTestDSN(dbName string) string {
 	if !strings.Contains(host, ":") {
 		host += ":3306"
 	}
-	fmt.Fprintf(&buf, "tcp(%s)/%s?strict=true", host, dbName)
+	fmt.Fprintf(&buf, "tcp(%s)/%s", host, dbName)
 	return buf.String()
 }
 


### PR DESCRIPTION
- Adding configuration files for CircleCI 2.0
- Disabling `strict mode` in `base_test.go` for compatibility with [go-sql-driver/mysql](https://github.com/go-sql-driver/mysql) versions later than go-sql-driver/mysql@a8b7ed4454a6a4f98f85d3ad558cd6d97cec6959