### PR TITLE
Add a getter for table.

### DIFF
--- a/db.go
+++ b/db.go
@@ -308,6 +308,11 @@ func (m *Model) All() ValExprBuilder {
 	return m.Table.All()
 }
 
+// GetTable gets a pointer to the table
+func (m *Model) GetTable() *Table {
+	return &m.Table
+}
+
 func getColumnNames(columns []*Column) []string {
 	var colNames []string
 	for _, c := range columns {


### PR DESCRIPTION
If you create functions that accept a Table pointer, you've got to do myFunc(&myModel.Table), I'd like to be able to do myFunc(myModel.GetTable())