### PR TITLE
Support comments in builders and DB functions

### DIFF
--- a/args.go
+++ b/args.go
@@ -15,6 +15,7 @@
 package squalor
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 )
@@ -70,6 +71,16 @@ var kindsToBaseType = map[reflect.Kind]reflect.Type{
 	reflect.String:  reflect.TypeOf(string("")),
 }
 
+type contextKey string
+
+func (c contextKey) String() string {
+	return "square/squalor context key " + string(c)
+}
+
+var (
+	ContextKeyComments = contextKey("comments")
+)
+
 func argsConvert(from []interface{}) []interface{} {
 	to := make([]interface{}, len(from))
 	for i, arg := range from {
@@ -110,4 +121,9 @@ func asKind(value reflect.Value) interface{} {
 	default:
 		panic(fmt.Sprintf("unmapped base kind %s", kind))
 	}
+}
+
+func comments(ctx context.Context) ([]string, bool) {
+	comment, ok := ctx.Value(ContextKeyComments).([]string)
+	return comment, ok
 }

--- a/ast.go
+++ b/ast.go
@@ -185,6 +185,9 @@ func (node *Select) Serialize(w Writer) error {
 	if _, err := w.Write(astSelect); err != nil {
 		return err
 	}
+	if err := node.Comments.Serialize(w); err != nil {
+		return err
+	}
 	if _, err := io.WriteString(w, node.Distinct); err != nil {
 		return err
 	}
@@ -398,7 +401,7 @@ type Comments []string
 
 func (node Comments) Serialize(w Writer) error {
 	for _, c := range node {
-		if _, err := io.WriteString(w, c); err != nil {
+		if err := encodeSQLComment(w, c); err != nil {
 			return nil
 		}
 		if _, err := w.Write(astSpace); err != nil {

--- a/builder.go
+++ b/builder.go
@@ -65,6 +65,13 @@ func (b *DeleteBuilder) Where(expr BoolExpr) *DeleteBuilder {
 	return b
 }
 
+// Comments sets comments for the statement, replacing any
+// existing comments.
+func (b *DeleteBuilder) Comments(comments []string) *DeleteBuilder {
+	b.Delete.Comments = comments
+	return b
+}
+
 // abstractTable represents either a concrete table or the result of
 // joining two tables.
 type abstractTable interface {
@@ -255,6 +262,13 @@ func (b *InsertBuilder) AddRows(rows Values) *InsertBuilder {
 	return b
 }
 
+// Comments sets comments for the statement, replacing any
+// existing comments.
+func (b *InsertBuilder) Comments(comments []string) *InsertBuilder {
+	b.Insert.Comments = comments
+	return b
+}
+
 // OnDupKeyUpdate specifies an ON DUPLICATE KEY UPDATE expression to
 // be performed when a duplicate primary key is encountered during
 // insertion. The specified column must exist within the table being
@@ -332,6 +346,13 @@ func (b *ReplaceBuilder) AddRows(rows Values) *ReplaceBuilder {
 	} else {
 		b.Insert.Rows = append(b.Insert.Rows.(Values), rows...)
 	}
+	return b
+}
+
+// Comments sets comments for the statement, replacing any
+// existing comments.
+func (b *ReplaceBuilder) Comments(comments []string) *ReplaceBuilder {
+	b.Insert.Comments = comments
 	return b
 }
 
@@ -450,6 +471,13 @@ func (b *SelectBuilder) Where(expr BoolExpr) *SelectBuilder {
 	return b
 }
 
+// Comments sets comments for the statement, replacing any
+// existing comments.
+func (b *SelectBuilder) Comments(comments []string) *SelectBuilder {
+	b.Select.Comments = comments
+	return b
+}
+
 // Having sets the HAVING clause for the statement, replacing any
 // existing having clause.
 func (b *SelectBuilder) Having(expr BoolExpr) *SelectBuilder {
@@ -544,6 +572,13 @@ func (b *UpdateBuilder) Where(expr BoolExpr) *UpdateBuilder {
 		Type: astWhere,
 		Expr: unwrapBoolExpr(expr),
 	}
+	return b
+}
+
+// Comments sets comments for the statement, replacing any
+// existing comments.
+func (b *UpdateBuilder) Comments(comments []string) *UpdateBuilder {
+	b.Update.Comments = comments
 	return b
 }
 

--- a/builder_test.go
+++ b/builder_test.go
@@ -52,6 +52,9 @@ func TestDeleteBuilder(t *testing.T) {
 		// Limit
 		{users.Delete().Limit(10),
 			"DELETE FROM `users` LIMIT 10"},
+		// Comments
+		{users.Delete().Comments([]string{"quux", "quuz"}),
+			"DELETE /* quux */ /* quuz */ FROM `users`"},
 		// Joins
 		{users.InnerJoin(objects).Delete(),
 			"DELETE FROM `users` INNER JOIN `objects`"},
@@ -72,8 +75,8 @@ func TestDeleteBuilder(t *testing.T) {
 		{users.RightJoin(objects).Delete(users),
 			"DELETE `users` FROM `users` RIGHT JOIN `objects`"},
 		// Subquery
-		{users.Delete().Where(foo.InTuple(&Subquery{objects.Select(objects.C("foo")).Where(objects.C("foo").Gt(10))})),
-			"DELETE FROM `users` WHERE `users`.`foo` IN (SELECT `objects`.`foo` FROM `objects` WHERE `objects`.`foo` > 10)"},
+		{users.Delete().Where(foo.InTuple(&Subquery{objects.Select(objects.C("foo")).Comments([]string{"corge"}).Where(objects.C("foo").Gt(10))})).Comments([]string{"grault"}),
+			"DELETE /* grault */ FROM `users` WHERE `users`.`foo` IN (SELECT /* corge */ `objects`.`foo` FROM `objects` WHERE `objects`.`foo` > 10)"},
 	}
 
 	for _, c := range testCases {
@@ -132,6 +135,8 @@ func TestInsertBuilder(t *testing.T) {
 			"INSERT INTO `users` (`foo`) VALUES ('bar'), ('qux')"},
 		{users.Insert("foo", "bar").Add("qux", 2),
 			"INSERT INTO `users` (`foo`, `bar`) VALUES ('qux', 2)"},
+		{users.Insert(foo).Add("bar").Add("qux").Comments([]string{"quux", "quuz"}),
+			"INSERT /* quux */ /* quuz */ INTO `users` (`foo`) VALUES ('bar'), ('qux')"},
 		{users.Insert("foo").Add("bar").OnDupKeyUpdate("bar", 2),
 			"INSERT INTO `users` (`foo`) VALUES ('bar') ON DUPLICATE KEY UPDATE `users`.`bar` = 2"},
 		{users.Insert("foo").Add("bar").OnDupKeyUpdateColumn("bar"),
@@ -151,6 +156,8 @@ func TestInsertBuilder(t *testing.T) {
 			"INSERT IGNORE INTO `users` (`foo`) VALUES ('bar'), ('qux')"},
 		{users.InsertIgnore("foo", "bar").Add("qux", 2),
 			"INSERT IGNORE INTO `users` (`foo`, `bar`) VALUES ('qux', 2)"},
+		{users.InsertIgnore(foo).Add("bar").Add("qux").Comments([]string{"quux", "quuz"}),
+			"INSERT IGNORE /* quux */ /* quuz */ INTO `users` (`foo`) VALUES ('bar'), ('qux')"},
 		{users.InsertIgnore("foo").Add("bar").OnDupKeyUpdate("bar", 2),
 			"INSERT IGNORE INTO `users` (`foo`) VALUES ('bar') ON DUPLICATE KEY UPDATE `users`.`bar` = 2"},
 		{users.InsertIgnore("foo").Add("bar").OnDupKeyUpdateColumn("bar"),
@@ -223,6 +230,9 @@ func TestReplaceBuilder(t *testing.T) {
 			"REPLACE INTO `users` (`foo`) VALUES ('bar'), ('qux')"},
 		{users.Replace("foo", "bar").Add("qux", 2),
 			"REPLACE INTO `users` (`foo`, `bar`) VALUES ('qux', 2)"},
+		{users.Replace(foo).Add("bar").Add("qux").Comments([]string{"quux", "quuz"}),
+			"REPLACE /* quux */ /* quuz */ INTO `users` (`foo`) VALUES ('bar'), ('qux')"},
+
 	}
 
 	for _, c := range testCases {
@@ -279,6 +289,8 @@ func TestUpdateBuilder(t *testing.T) {
 			"UPDATE `users` SET `users`.`foo` = 'bar' ORDER BY `users`.`bar`"},
 		{users.Update().Set(foo, "bar").Limit(2),
 			"UPDATE `users` SET `users`.`foo` = 'bar' LIMIT 2"},
+		{users.Update().Set(foo, "bar").Comments([]string{"quux", "quuz"}),
+			"UPDATE /* quux */ /* quuz */ `users` SET `users`.`foo` = 'bar'"},
 	}
 
 	for _, c := range testCases {
@@ -469,6 +481,8 @@ func TestSelectBuilder(t *testing.T) {
 			"SELECT * FROM `users` FOR UPDATE"},
 		{users.Select("*").WithSharedLock(),
 			"SELECT * FROM `users` LOCK IN SHARE MODE"},
+		{users.Select("*").Comments([]string{"quux", "quuz"}),
+			"SELECT /* quux */ /* quuz */ * FROM `users`"},
 		// Joins
 		{users.InnerJoin(objects).Select("*"),
 			"SELECT * FROM `users` INNER JOIN `objects`"},

--- a/db.go
+++ b/db.go
@@ -1587,6 +1587,11 @@ func deleteModel(ctx context.Context, model *Model, exec Executor, list []interf
 				b.Where(andExpr.And(inExpr))
 			}
 
+			comments, ok := comments(ctx)
+			if ok {
+				b.Comments(comments)
+			}
+
 			res, err := exec.ExecContext(ctx, &b)
 			if err != nil {
 				return -1, err
@@ -1664,6 +1669,10 @@ func getObject(ctx context.Context, db *DB, exec Executor, obj interface{}, keys
 		}
 	}
 	q.Where(where)
+	comments, ok := comments(ctx)
+	if ok {
+		q.Comments(comments)
+	}
 
 	v := reflect.Indirect(reflect.ValueOf(obj))
 	dest := make([]interface{}, len(model.get.traversals))
@@ -1746,10 +1755,18 @@ func insertModel(ctx context.Context, model *Model, exec Executor, getPlan func(
 	if plan.replaceBuilder != nil {
 		b := *plan.replaceBuilder
 		b.AddRows(rows)
+		comments, ok := comments(ctx)
+		if ok {
+			b.Comments(comments)
+		}
 		serializer = &b
 	} else {
 		b := *plan.insertBuilder
 		b.AddRows(rows)
+		comments, ok := comments(ctx)
+		if ok {
+			b.Comments(comments)
+		}
 		serializer = &b
 	}
 
@@ -1879,6 +1896,11 @@ func updateModel(ctx context.Context, model *Model, exec Executor, list []interf
 			}
 		}
 		b.Where(where)
+
+		comments, ok := comments(ctx)
+		if ok {
+			b.Comments(comments)
+		}
 
 		res, err := exec.ExecContext(ctx, b)
 		if err != nil {


### PR DESCRIPTION
Comments were already supported at the serialization layer. This adds:
* Comments() functions to all builders
* A way to inject comments via the context for
Insert/Update/Upsert/Replace/DeleteContext() DB functions