### PR TITLE
Remove All() warning log and update comment

### DIFF
--- a/db.go
+++ b/db.go
@@ -318,17 +318,14 @@ func newModel(db *DB, t reflect.Type, table Table) (*Model, error) {
 	return m, nil
 }
 
-// All builds a val expression to select all columns mapped by the model.
+// AllMapped builds a val expression to select all columns that are mapped by the model.
 func (m *Model) AllMapped() ValExprBuilder {
 	return m.C(m.mappedColNames...)
 }
 
-// All builds a val expression to select all columns on the model's Table.
-// WARNING: This is probably not the method you want. Call AllMapped() instead.
+// All builds a val expression to select all columns on the model's Table - including unmapped columns.
+// WARNING: This function does not respect the IgnoreUnmappedCols setting. Use of AllMapped() is preferred.
 func (m *Model) All() ValExprBuilder {
-	if m.db.IgnoreUnmappedCols {
-		fmt.Print("WARNING: Calling All() on a model will include unmapped columns if they are present.")
-	}
 	return m.Table.All()
 }
 


### PR DESCRIPTION
Use of `All()` with the setting `IgnoreUnmappedCols` set to true can result in spamming logs to stdout. Since `All()` may be used in high QPS codepaths, it's safer to avoid logging. 

This PR removes the unnecessary log and adds more context to the comment suggesting the use of `AllMapped()`, allowing developers make their own decision. `AllMapped()` is preferred, but since some developers may still use this function, it seems best to remove the log. No functionality is changed - this PR only removes the log and updates the comment.

Note: this log previously used `Print()` so all logs were on one line and not particularly readable anyway.