### PR TITLE
Fix query deadline writer

### DIFF
--- a/db.go
+++ b/db.go
@@ -518,6 +518,8 @@ func mySql57DeadlineQueryRewriter(db *DB, query interface{}, millis int64) (quer
 	if err != nil {
 		return nil, err
 	}
+	// Remove white space so that it does not affect replacing SELECT
+	querystr = strings.TrimSpace(querystr)
 
 	if strings.HasPrefix(querystr, "SELECT ") || strings.HasPrefix(querystr, "(SELECT ") {
 		querystr = strings.Replace(querystr, "SELECT ", fmt.Sprintf("SELECT /*+ MAX_EXECUTION_TIME(%d) */ ", millis), 1)

--- a/db_test.go
+++ b/db_test.go
@@ -1198,6 +1198,17 @@ func TestWithMySql57Deadline(t *testing.T) {
 		!strings.HasSuffix(logger.lastQuery, ") */ * FROM objects ORDER BY ID ASC LIMIT 1) UNION (SELECT * FROM objects ORDER BY id DESC LIMIT 1)") {
 		t.Fatalf("Expected %q, got %q", "(SELECT /*+ MAX_EXECUTION_TIME(?) */ FROM objects ORDER BY ID ASC LIMIT 1) UNION (SELECT * FROM objects ORDER BY id DESC LIMIT 1)", logger.lastQuery)
 	}
+
+	// Test with white space
+	logger.lastQuery = ""
+
+	db.QueryRow(`
+     SELECT * from objects LIMIT 1`)
+
+	if !strings.HasPrefix(logger.lastQuery, "SELECT /*+ MAX_EXECUTION_TIME(") ||
+		!strings.HasSuffix(logger.lastQuery, ") */ * from objects LIMIT 1") {
+		t.Fatalf("Expected %q, got %q", "SELECT /*+ MAX_EXECUTION_TIME(9999) */ * from objects LIMIT 1", logger.lastQuery)
+	}
 }
 
 func TestWithoutDeadline(t *testing.T) {


### PR DESCRIPTION
Squalor will not add the MAX_EXECUTION_TIME statement to queries with white space before select.