### PR TITLE
Add MAX_EXECUTION_TIME hint to existing optimizer hint comment if one exists

### DIFF
--- a/db.go
+++ b/db.go
@@ -553,7 +553,11 @@ func perconaDeadlineQueryRewriter(db *DB, query string, deadline time.Duration) 
 
 func mySql57DeadlineQueryRewriter(db *DB, query string, deadline time.Duration) (queryWithDeadline string) {
 	if deadline.Milliseconds() > 0 && (strings.HasPrefix(query, "SELECT ") || strings.HasPrefix(query, "(SELECT ")) {
-		return strings.Replace(query, "SELECT ", fmt.Sprintf("SELECT /*+ MAX_EXECUTION_TIME(%d) */ ", deadline.Milliseconds()), 1)
+		if strings.Contains(query, "SELECT /*+ ") {
+			return strings.Replace(query, "SELECT /*+ ", fmt.Sprintf("SELECT /*+ MAX_EXECUTION_TIME(%d) ", deadline.Milliseconds()), 1)
+		} else {
+			return strings.Replace(query, "SELECT ", fmt.Sprintf("SELECT /*+ MAX_EXECUTION_TIME(%d) */ ", deadline.Milliseconds()), 1)
+		}
 	}
 	return query
 }

--- a/db_test.go
+++ b/db_test.go
@@ -1211,6 +1211,16 @@ func TestWithMySql57Deadline(t *testing.T) {
 		!strings.HasSuffix(logger.lastQuery, ") */ * from objects LIMIT 1") {
 		t.Fatalf("Expected %q, got %q", "SELECT /*+ MAX_EXECUTION_TIME(9999) */ * from objects LIMIT 1", logger.lastQuery)
 	}
+
+	// Test query that already has an optimizer hint
+	logger.lastQuery = ""
+
+	db.QueryRow(`SELECT /*+ NO_RANGE_OPTIMIZATION(objects) */ * from objects LIMIT 1`)
+
+	if !strings.HasPrefix(logger.lastQuery, "SELECT /*+ MAX_EXECUTION_TIME(") ||
+		!strings.HasSuffix(logger.lastQuery, ") NO_RANGE_OPTIMIZATION(objects) */ * from objects LIMIT 1") {
+		t.Fatalf("Expected %q, got %q", "SELECT /*+ MAX_EXECUTION_TIME(9999) NO_RANGE_OPTIMIZATION(objects) */ * from objects LIMIT 1", logger.lastQuery)
+	}
 }
 
 func TestWithMySql57DefaultDeadline(t *testing.T) {


### PR DESCRIPTION
This will allow us to write queries that use other [optimizer hints](https://dev.mysql.com/doc/refman/8.0/en/optimizer-hints.html#optimizer-hints-syntax) without them getting clobbered by Squalor