### PR TITLE
Add Vitess query deadline support via QUERY_TIMEOUT_MS comment directive

### DIFF
--- a/db.go
+++ b/db.go
@@ -572,6 +572,9 @@ func mySql57DeadlineQueryRewriter(db *DB, query string, deadline time.Duration) 
 
 func vitessDeadlineQueryRewriter(db *DB, query string, deadline time.Duration) (queryWithDeadline string) {
 	if deadline.Milliseconds() > 0 && (strings.HasPrefix(query, "SELECT ") || strings.HasPrefix(query, "(SELECT ")) {
+		if strings.Contains(strings.ToUpper(query), "QUERY_TIMEOUT_MS") {
+			return query
+		}
 		return fmt.Sprintf("/*vt+ QUERY_TIMEOUT_MS=%d */ %s", deadline.Milliseconds(), query)
 	}
 	return query

--- a/db.go
+++ b/db.go
@@ -429,6 +429,14 @@ func QueryDeadlineMySQL57(db *DB) error {
 	return nil
 }
 
+// When passed as an option to NewDB(), enables query deadlines on Vitess.
+// Query deadlines only affect SELECT queries run via the Executor.Query function.
+// It is up to Vitess to enforce the deadline via the QUERY_TIMEOUT_MS comment directive.
+func QueryDeadlineVitess(db *DB) error {
+	db.deadlineQueryRewriter = vitessDeadlineQueryRewriter
+	return nil
+}
+
 // When passed as an option to NewDB(), enables query deadlines on MySql 5.7.4 or later.
 // Query deadlines only affect SELECT queries run via the Executor.Query function.
 // It us up to the underlying database engine to enforce the deadline.
@@ -558,6 +566,13 @@ func mySql57DeadlineQueryRewriter(db *DB, query string, deadline time.Duration) 
 		} else {
 			return strings.Replace(query, "SELECT ", fmt.Sprintf("SELECT /*+ MAX_EXECUTION_TIME(%d) */ ", deadline.Milliseconds()), 1)
 		}
+	}
+	return query
+}
+
+func vitessDeadlineQueryRewriter(db *DB, query string, deadline time.Duration) (queryWithDeadline string) {
+	if deadline.Milliseconds() > 0 && (strings.HasPrefix(query, "SELECT ") || strings.HasPrefix(query, "(SELECT ")) {
+		return fmt.Sprintf("/*vt+ QUERY_TIMEOUT_MS=%d */ %s", deadline.Milliseconds(), query)
 	}
 	return query
 }

--- a/db_test.go
+++ b/db_test.go
@@ -1376,6 +1376,15 @@ func TestWithVitessDeadline(t *testing.T) {
 	if strings.Contains(logger.lastQuery, "QUERY_TIMEOUT_MS") {
 		t.Fatalf("Expected INSERT query to not be rewritten, got %q", logger.lastQuery)
 	}
+
+	// Test query that already has QUERY_TIMEOUT_MS is not rewritten
+	logger.lastQuery = ""
+
+	db.QueryRow("/*vt+ QUERY_TIMEOUT_MS=500 */ SELECT * from objects LIMIT 1")
+
+	if logger.lastQuery != "/*vt+ QUERY_TIMEOUT_MS=500 */ SELECT * from objects LIMIT 1" {
+		t.Fatalf("Expected existing QUERY_TIMEOUT_MS to be preserved, got %q", logger.lastQuery)
+	}
 }
 
 func TestWithVitessDefaultDeadline(t *testing.T) {

--- a/db_test.go
+++ b/db_test.go
@@ -1262,6 +1262,161 @@ func TestWithMySql57DefaultDeadline(t *testing.T) {
 	}
 }
 
+func TestWithVitessDeadline(t *testing.T) {
+	logger := &TestLogger{}
+	db := makeTestDBWithOptions(t, []DBOption{QueryDeadlineVitess, SetQueryLogger(logger)}, usersDDL)
+	defer db.Close()
+
+	now := time.Now()
+	later := now.Add(time.Duration(10 * time.Second))
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, "user_id", "123")
+
+	var cancel func()
+	ctx, cancel = context.WithDeadline(ctx, later)
+	defer cancel()
+
+	db = db.WithContext(ctx).(*DB)
+	if dbDeadline, _ := db.Context().Deadline(); dbDeadline != later {
+		t.Fatalf("Expected db.GetContext.Deadline() to return %v, got %v", later, dbDeadline)
+	}
+
+	// Test tx.Query
+	logger.lastQuery = ""
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if txDeadline, _ := tx.Context().Deadline(); txDeadline != later {
+		t.Fatalf("Expected tx.GetContext.Deadline() to return %v, got %v", later, txDeadline)
+	}
+
+	tx.Query("SELECT * from objects")
+
+	if !strings.HasPrefix(logger.lastQuery, "/*vt+ QUERY_TIMEOUT_MS=") ||
+		!strings.HasSuffix(logger.lastQuery, " */ SELECT * from objects") {
+		t.Fatalf("Expected %q, got %q", "/*vt+ QUERY_TIMEOUT_MS=9999 */ SELECT * from objects", logger.lastQuery)
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test db.Query
+	logger.lastQuery = ""
+
+	db.Query("SELECT * from objects")
+	if !strings.HasPrefix(logger.lastQuery, "/*vt+ QUERY_TIMEOUT_MS=") ||
+		!strings.HasSuffix(logger.lastQuery, " */ SELECT * from objects") {
+		t.Fatalf("Expected %q, got %q", "/*vt+ QUERY_TIMEOUT_MS=9999 */ SELECT * from objects", logger.lastQuery)
+	}
+
+	// Test tx.QueryRow
+	logger.lastQuery = ""
+
+	tx, err = db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if txDeadline, _ := tx.Context().Deadline(); txDeadline != later {
+		t.Fatalf("Expected tx.GetContext.Deadline() to return %v, got %v", later, txDeadline)
+	}
+
+	tx.QueryRow("SELECT * from objects LIMIT 1")
+
+	if !strings.HasPrefix(logger.lastQuery, "/*vt+ QUERY_TIMEOUT_MS=") ||
+		!strings.HasSuffix(logger.lastQuery, " */ SELECT * from objects LIMIT 1") {
+		t.Fatalf("Expected %q, got %q", "/*vt+ QUERY_TIMEOUT_MS=9999 */ SELECT * from objects LIMIT 1", logger.lastQuery)
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test db.QueryRow
+	logger.lastQuery = ""
+
+	db.QueryRow("SELECT * from objects LIMIT 1")
+
+	if !strings.HasPrefix(logger.lastQuery, "/*vt+ QUERY_TIMEOUT_MS=") ||
+		!strings.HasSuffix(logger.lastQuery, " */ SELECT * from objects LIMIT 1") {
+		t.Fatalf("Expected %q, got %q", "/*vt+ QUERY_TIMEOUT_MS=9999 */ SELECT * from objects LIMIT 1", logger.lastQuery)
+	}
+
+	// Test nested queries
+	logger.lastQuery = ""
+
+	db.QueryRow("(SELECT * FROM objects ORDER BY ID ASC LIMIT 1) UNION (SELECT * FROM objects ORDER BY id DESC LIMIT 1)")
+
+	if !strings.HasPrefix(logger.lastQuery, "/*vt+ QUERY_TIMEOUT_MS=") ||
+		!strings.HasSuffix(logger.lastQuery, " */ (SELECT * FROM objects ORDER BY ID ASC LIMIT 1) UNION (SELECT * FROM objects ORDER BY id DESC LIMIT 1)") {
+		t.Fatalf("Expected %q, got %q", "/*vt+ QUERY_TIMEOUT_MS=9999 */ (SELECT ...) UNION ...", logger.lastQuery)
+	}
+
+	// Test with white space
+	logger.lastQuery = ""
+
+	db.QueryRow(`
+     SELECT * from objects LIMIT 1`)
+
+	if !strings.HasPrefix(logger.lastQuery, "/*vt+ QUERY_TIMEOUT_MS=") ||
+		!strings.HasSuffix(logger.lastQuery, " */ SELECT * from objects LIMIT 1") {
+		t.Fatalf("Expected %q, got %q", "/*vt+ QUERY_TIMEOUT_MS=9999 */ SELECT * from objects LIMIT 1", logger.lastQuery)
+	}
+
+	// Test non-SELECT query is not rewritten
+	logger.lastQuery = ""
+
+	db.Exec("INSERT INTO users (name) VALUES ('test')")
+
+	if strings.Contains(logger.lastQuery, "QUERY_TIMEOUT_MS") {
+		t.Fatalf("Expected INSERT query to not be rewritten, got %q", logger.lastQuery)
+	}
+}
+
+func TestWithVitessDefaultDeadline(t *testing.T) {
+	logger := &TestLogger{}
+	db := makeTestDBWithOptions(t, []DBOption{QueryDeadlineVitess, QueryDeadlineDefault(time.Minute), SetQueryLogger(logger)}, usersDDL)
+	defer db.Close()
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, "user_id", "123")
+
+	db = db.WithContext(ctx).(*DB)
+
+	logger.lastQuery = ""
+
+	db.Query("SELECT * from objects")
+	if logger.lastQuery != "/*vt+ QUERY_TIMEOUT_MS=60000 */ SELECT * from objects" {
+		t.Fatalf("Expected %q, got %q", "/*vt+ QUERY_TIMEOUT_MS=60000 */ SELECT * from objects", logger.lastQuery)
+	}
+
+	var cancel func()
+	ctx, cancel = context.WithDeadline(ctx, time.Now().Add(10*time.Second))
+	defer cancel()
+
+	db = db.WithContext(ctx).(*DB)
+
+	logger.lastQuery = ""
+
+	db.Query("SELECT * from objects")
+	if !strings.HasPrefix(logger.lastQuery, "/*vt+ QUERY_TIMEOUT_MS=") ||
+		!strings.HasSuffix(logger.lastQuery, " */ SELECT * from objects") {
+		t.Fatalf("Expected %q, got %q", "/*vt+ QUERY_TIMEOUT_MS=9999 */ SELECT * from objects", logger.lastQuery)
+	}
+
+	lParen := strings.Index(logger.lastQuery, "=")
+	rParen := strings.Index(logger.lastQuery, " */")
+	millis, _ := strconv.Atoi(logger.lastQuery[lParen+1 : rParen])
+	if millis > 10000 {
+		t.Fatalf("Expected deadline <= 10000, got %d", millis)
+	}
+}
+
 func TestWithoutDeadline(t *testing.T) {
 	logger := &TestLogger{}
 	db := makeTestDBWithOptions(t, []DBOption{SetQueryLogger(logger)}, usersDDL)


### PR DESCRIPTION
## Summary

Adds a new `QueryDeadlineVitess` `DBOption` that enables query timeouts using Vitess's `/*vt+ QUERY_TIMEOUT_MS=<ms> */` comment directive syntax.

## Changes

- **`QueryDeadlineVitess`** — new `DBOption`, follows the same pattern as `QueryDeadlinePercona56` and `QueryDeadlineMySQL57`
- **`vitessDeadlineQueryRewriter`** — prepends the Vitess comment directive to SELECT queries (including parenthesized unions). Non-SELECT queries are left unchanged, matching Vitess's limitation.
- **Tests** — `TestWithVitessDeadline` and `TestWithVitessDefaultDeadline` covering Query/QueryRow on DB and Tx, nested queries, whitespace trimming, non-SELECT passthrough, and default deadline behavior.

## Usage

```go
db, err := squalor.NewDB(sqlDB, squalor.QueryDeadlineVitess)
```

Optionally with a default deadline:

```go
db, err := squalor.NewDB(sqlDB, squalor.QueryDeadlineVitess, squalor.QueryDeadlineDefault(30 * time.Second))
```

## References

- [Vitess Comment Directives docs](https://vitess.io/docs/23.0/user-guides/configuration-advanced/comment-directives/)