### PR TITLE
[codex] Add auto_id tag support

### DIFF
--- a/db.go
+++ b/db.go
@@ -162,11 +162,11 @@ func makeInsertPlan(m *Model, replace bool, insertIgnore bool) insertPlan {
 	var columns []interface{}
 	for _, col := range m.mappedColumns {
 		columns = append(columns, m.Table.C(col.Name))
-		if col.AutoIncr {
-			f, ok := m.fields[col.Name]
-			if !ok {
-				panic(fmt.Errorf("%s: unable to find field %s", m.Name, col))
-			}
+		f, ok := m.fields[col.Name]
+		if !ok {
+			panic(fmt.Errorf("%s: unable to find field %s", m.Name, col))
+		}
+		if col.AutoIncr || f.autoID {
 			p.autoIncr = f.Index
 			switch f.Type.Kind() {
 			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
@@ -204,7 +204,7 @@ func makeUpsertPlan(m *Model) insertPlan {
 		primaryKey[col.Name] = true
 	}
 	for _, col := range m.mappedColumns {
-		if col.AutoIncr || primaryKey[col.Name] {
+		if col.AutoIncr || m.fields[col.Name].autoID || primaryKey[col.Name] {
 			continue
 		}
 		p.insertBuilder.OnDupKeyUpdateColumn(col.Name)
@@ -245,7 +245,7 @@ func makeUpdatePlan(m *Model) updatePlan {
 
 	var setColumns []string
 	for _, col := range m.mappedColumns {
-		if col.AutoIncr || primaryKey[col.Name] || m.fields[col.Name].noupdate {
+		if col.AutoIncr || primaryKey[col.Name] || m.fields[col.Name].noupdate || m.fields[col.Name].autoID {
 			continue
 		}
 		setColumns = append(setColumns, col.Name)

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -30,6 +30,11 @@ type singleCol struct {
 	B int `db:"b"`
 }
 
+type singleColAutoID struct {
+	A int `db:"a,auto_id"`
+	B int `db:"b"`
+}
+
 // multiCol has a primary key composed of multiple columns. See
 // newTestStatementsDB.
 type multiCol struct {
@@ -62,6 +67,12 @@ func newTestStatementsDB(t *testing.T) *DB {
 		{
 			"single",
 			singleCol{},
+			1,
+			nil,
+		},
+		{
+			"single_auto_id",
+			singleColAutoID{},
 			1,
 			nil,
 		},
@@ -113,10 +124,11 @@ func newTestStatementsDB(t *testing.T) *DB {
 }
 
 type dummyResult struct {
+	lastInsertID int64
 }
 
 func (r dummyResult) LastInsertId() (int64, error) {
-	return 0, nil
+	return r.lastInsertID, nil
 }
 
 func (r dummyResult) RowsAffected() (int64, error) {
@@ -125,8 +137,9 @@ func (r dummyResult) RowsAffected() (int64, error) {
 
 type recordingExecutor struct {
 	*DB
-	exec  []string
-	query []string
+	exec         []string
+	query        []string
+	lastInsertID int64
 }
 
 func (r *recordingExecutor) Exec(stmt interface{}, args ...interface{}) (sql.Result, error) {
@@ -155,7 +168,7 @@ func (r *recordingExecutor) ExecContext(_ context.Context, stmt interface{}, arg
 	}
 
 	r.exec = append(r.exec, querystr)
-	return dummyResult{}, nil
+	return dummyResult{lastInsertID: r.lastInsertID}, nil
 }
 
 func (r *recordingExecutor) QueryRow(query interface{}, args ...interface{}) *Row {
@@ -412,6 +425,25 @@ func TestDBInsertStatements(t *testing.T) {
 		if !reflect.DeepEqual([]string{c.expected}, recorder.exec) {
 			t.Errorf("Expected %+v, but got %+v", c.expected, recorder.exec)
 		}
+	}
+}
+
+func TestDBInsertAutoIDPopulatesID(t *testing.T) {
+	db := newTestStatementsDB(t)
+	recorder := &recordingExecutor{
+		DB:           db,
+		lastInsertID: 42,
+	}
+	obj := &singleColAutoID{B: 1}
+	model, err := db.getModel(deref(reflect.TypeOf(obj)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := insertModel(context.Background(), model, recorder, getInsert, []interface{}{obj}); err != nil {
+		t.Fatal(err)
+	}
+	if obj.A != 42 {
+		t.Fatalf("Expected auto_id field to be populated with 42, but got %d", obj.A)
 	}
 }
 

--- a/doc.go
+++ b/doc.go
@@ -137,6 +137,15 @@ Then we could create a new user by doing:
     }
     // u.ID will be correctly populated at this point
 
+If the database driver still returns the generated value through
+LastInsertId, but the table metadata does not mark the column as auto
+increment, annotate the model field with auto_id:
+
+    type User struct {
+      ID   int64  `db:"id,auto_id"`
+      Name string `db:"name"`
+    }
+
 Replace
 
 The Replace method replaces a row in table, either inserting the row

--- a/reflect.go
+++ b/reflect.go
@@ -24,6 +24,7 @@ type fieldDesc struct {
 	reflect.StructField
 	optlock  bool
 	noupdate bool
+	autoID   bool
 }
 
 type fieldMap map[string]fieldDesc
@@ -32,6 +33,7 @@ const (
 	tagName        = "db"
 	tagSubOptlock  = "optlock"
 	tagSubNoUpdate = "noupdate"
+	tagSubAutoID   = "auto_id"
 )
 
 // getMapping returns a mapping for the type t, using the tagName and
@@ -54,7 +56,7 @@ func getMapping(t reflect.Type, mapFunc func(string) string) fieldMap {
 		for fieldPos := 0; fieldPos < tq.t.NumField(); fieldPos++ {
 			f := tq.t.Field(fieldPos)
 
-			name, optlock, noupdate := readTag(f.Tag.Get(tagName))
+			name, optlock, noupdate, autoID := readTag(f.Tag.Get(tagName))
 
 			// Breadth first search of untagged anonymous embedded structs.
 			if f.Anonymous && f.Type.Kind() == reflect.Struct && name == "" {
@@ -88,13 +90,13 @@ func getMapping(t reflect.Type, mapFunc func(string) string) fieldMap {
 			// Add it to the map at the current position.
 			sf := f
 			sf.Index = appendIndex(tq.p, fieldPos)
-			m[name] = fieldDesc{sf, optlock, noupdate}
+			m[name] = fieldDesc{sf, optlock, noupdate, autoID}
 		}
 	}
 	return m
 }
 
-func readTag(tag string) (name string, optLock bool, noUpdate bool) {
+func readTag(tag string) (name string, optLock bool, noUpdate bool, autoID bool) {
 	values := strings.Split(tag, ",")
 	name = values[0]
 	if len(values) > 1 {
@@ -104,10 +106,12 @@ func readTag(tag string) (name string, optLock bool, noUpdate bool) {
 				optLock = true
 			case tagSubNoUpdate:
 				noUpdate = true
+			case tagSubAutoID:
+				autoID = true
 			}
 		}
 	}
-	return name, optLock, noUpdate
+	return name, optLock, noUpdate, autoID
 }
 
 func getDBFields(t reflect.Type) fieldMap {

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -162,19 +162,21 @@ func TestReadTag(t *testing.T) {
 		name     string
 		optlock  bool
 		noupdate bool
+		autoID   bool
 	}{
-		{"-", "-", false, false},
-		{"foo", "foo", false, false},
-		{"foo,", "foo", false, false},
-		{"foo,optlock", "foo", true, false},
-		{",optlock", "", true, false},
-		{",wrong", "", false, false},
-		{",noupdate", "", false, true},
-		{",optlock,noupdate", "", true, true},
-		{",", "", false, false},
+		{"-", "-", false, false, false},
+		{"foo", "foo", false, false, false},
+		{"foo,", "foo", false, false, false},
+		{"foo,optlock", "foo", true, false, false},
+		{",optlock", "", true, false, false},
+		{",wrong", "", false, false, false},
+		{",noupdate", "", false, true, false},
+		{",auto_id", "", false, false, true},
+		{",optlock,noupdate,auto_id", "", true, true, true},
+		{",", "", false, false, false},
 	}
 	for _, c := range testCases {
-		name, optlock, noupdate := readTag(c.tag)
+		name, optlock, noupdate, autoID := readTag(c.tag)
 		if name != c.name {
 			t.Errorf("%s: expected name '%s', actual '%s'", c.tag, c.name, name)
 		}
@@ -183,6 +185,9 @@ func TestReadTag(t *testing.T) {
 		}
 		if noupdate != c.noupdate {
 			t.Errorf("%s: expected noupdate '%t', actual '%t'", c.tag, c.noupdate, noupdate)
+		}
+		if autoID != c.autoID {
+			t.Errorf("%s: expected autoID '%t', actual '%t'", c.tag, c.autoID, autoID)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Adds support for an `auto_id` db tag option so a mapped model field can participate in Squalor's generated-id writeback even when table metadata does not mark the column as `AUTO_INCREMENT`.

## Details

- Parses `db:\",auto_id\"` / `db:\"id,auto_id\"` into field metadata.
- Treats `auto_id` fields like auto-increment fields in insert planning for `LastInsertId()` population.
- Excludes `auto_id` fields from update and upsert assignment lists, matching existing auto-increment handling.
- Documents the tag and adds regression coverage for tag parsing and insert writeback.

## Validation

- `go test -vet=off ./...`

Note: plain `go test ./...` still fails on the existing vet/example issue: `ExampleTable_Join refers to unknown field or method: Table.Join`.