### PR TITLE
[codex] Expose bound model metadata

### DIFF
--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -50,6 +50,12 @@ type singleColOptlock struct {
 	V int `db:"v,optlock"`
 }
 
+type boundModelInfoObject struct {
+	ID      int    `db:"id"`
+	OwnerID int    `db:"owner_id"`
+	Name    string `db:"name"`
+}
+
 func newTestStatementsDB(t *testing.T) *DB {
 	db, _ := NewDB(nil)
 
@@ -110,6 +116,100 @@ func newTestStatementsDB(t *testing.T) *DB {
 		db.mappings[modelT] = m.fields
 	}
 	return db
+}
+
+func TestDBBoundModelsReturnsReadOnlyMetadata(t *testing.T) {
+	db, _ := NewDB(nil)
+
+	table := NewTable("bound_model_info_objects", boundModelInfoObject{})
+	table.ColumnMap["id"].AutoIncr = true
+	table.ColumnMap["id"].Nullable = false
+	table.ColumnMap["id"].sqlType = "bigint(20)"
+	table.ColumnMap["owner_id"].Nullable = false
+	table.ColumnMap["owner_id"].sqlType = "bigint(20)"
+	table.ColumnMap["name"].Nullable = true
+	table.ColumnMap["name"].sqlType = "varchar(255)"
+
+	primary := &Key{
+		Name:    "PRIMARY",
+		Primary: true,
+		Unique:  true,
+		Columns: []*Column{table.ColumnMap["id"]},
+	}
+	ownerIndex := &Key{
+		Name:    "idx_owner_name",
+		Unique:  false,
+		Columns: []*Column{table.ColumnMap["owner_id"], table.ColumnMap["name"]},
+	}
+	table.PrimaryKey = primary
+	table.Keys = []*Key{primary, ownerIndex}
+	table.KeyMap = map[string]*Key{
+		"PRIMARY":        primary,
+		"idx_owner_name": ownerIndex,
+	}
+
+	modelT := reflect.TypeOf(boundModelInfoObject{})
+	model, err := newModel(db, modelT, *table)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.models[modelT] = model
+	db.mappings[modelT] = model.fields
+
+	info := db.BoundModels()
+	if len(info) != 1 {
+		t.Fatalf("expected 1 bound model, got %d", len(info))
+	}
+
+	got := info[0]
+	if got.TableName != "bound_model_info_objects" {
+		t.Fatalf("expected table name %q, got %q", "bound_model_info_objects", got.TableName)
+	}
+	if got.ModelType != modelT {
+		t.Fatalf("expected model type %s, got %s", modelT, got.ModelType)
+	}
+
+	expectedColumns := []BoundColumnInfo{
+		{Name: "id", AutoIncr: true, Nullable: false, SQLType: "bigint(20)"},
+		{Name: "name", AutoIncr: false, Nullable: true, SQLType: "varchar(255)"},
+		{Name: "owner_id", AutoIncr: false, Nullable: false, SQLType: "bigint(20)"},
+	}
+	if !reflect.DeepEqual(expectedColumns, got.MappedColumns) {
+		t.Fatalf("expected mapped columns %+v, got %+v", expectedColumns, got.MappedColumns)
+	}
+
+	expectedPrimaryKey := BoundKeyInfo{
+		Name:    "PRIMARY",
+		Primary: true,
+		Unique:  true,
+		Columns: []string{"id"},
+	}
+	if !reflect.DeepEqual(expectedPrimaryKey, got.PrimaryKey) {
+		t.Fatalf("expected primary key %+v, got %+v", expectedPrimaryKey, got.PrimaryKey)
+	}
+
+	expectedIndexes := []BoundKeyInfo{
+		{Name: "PRIMARY", Primary: true, Unique: true, Columns: []string{"id"}},
+		{Name: "idx_owner_name", Primary: false, Unique: false, Columns: []string{"owner_id", "name"}},
+	}
+	if !reflect.DeepEqual(expectedIndexes, got.Indexes) {
+		t.Fatalf("expected indexes %+v, got %+v", expectedIndexes, got.Indexes)
+	}
+
+	info[0].MappedColumns[0].Name = "mutated"
+	info[0].PrimaryKey.Columns[0] = "mutated"
+	info[0].Indexes[0].Columns[0] = "mutated"
+
+	info = db.BoundModels()
+	if info[0].MappedColumns[0].Name != "id" {
+		t.Fatalf("expected mapped column metadata to be copied, got %+v", info[0].MappedColumns)
+	}
+	if info[0].PrimaryKey.Columns[0] != "id" {
+		t.Fatalf("expected primary key metadata to be copied, got %+v", info[0].PrimaryKey)
+	}
+	if info[0].Indexes[0].Columns[0] != "id" {
+		t.Fatalf("expected index metadata to be copied, got %+v", info[0].Indexes)
+	}
 }
 
 type dummyResult struct {

--- a/metadata.go
+++ b/metadata.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package squalor
+
+import (
+	"reflect"
+	"sort"
+)
+
+// BoundModelInfo contains read-only metadata about a model bound to a DB.
+type BoundModelInfo struct {
+	TableName     string
+	ModelType     reflect.Type
+	MappedColumns []BoundColumnInfo
+	PrimaryKey    BoundKeyInfo
+	Indexes       []BoundKeyInfo
+}
+
+// BoundColumnInfo contains read-only metadata about a mapped database column.
+type BoundColumnInfo struct {
+	Name     string
+	AutoIncr bool
+	Nullable bool
+	SQLType  string
+}
+
+// BoundKeyInfo contains read-only metadata about a database key or index.
+type BoundKeyInfo struct {
+	Name    string
+	Primary bool
+	Unique  bool
+	Columns []string
+}
+
+// BoundModels returns read-only metadata snapshots for all models bound to db.
+func (db *DB) BoundModels() []BoundModelInfo {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+
+	models := make([]BoundModelInfo, 0, len(db.models))
+	for modelType, model := range db.models {
+		models = append(models, boundModelInfo(modelType, model))
+	}
+
+	sort.Slice(models, func(i, j int) bool {
+		if models[i].TableName != models[j].TableName {
+			return models[i].TableName < models[j].TableName
+		}
+		return models[i].ModelType.String() < models[j].ModelType.String()
+	})
+	return models
+}
+
+func boundModelInfo(modelType reflect.Type, model *Model) BoundModelInfo {
+	info := BoundModelInfo{
+		TableName:     model.Name,
+		ModelType:     modelType,
+		MappedColumns: boundColumnInfos(model.mappedColumns),
+		PrimaryKey:    boundKeyInfo(model.PrimaryKey),
+		Indexes:       boundKeyInfos(model.Keys),
+	}
+	return info
+}
+
+func boundColumnInfos(columns []*Column) []BoundColumnInfo {
+	infos := make([]BoundColumnInfo, len(columns))
+	for i, column := range columns {
+		infos[i] = boundColumnInfo(column)
+	}
+	return infos
+}
+
+func boundColumnInfo(column *Column) BoundColumnInfo {
+	if column == nil {
+		return BoundColumnInfo{}
+	}
+	return BoundColumnInfo{
+		Name:     column.Name,
+		AutoIncr: column.AutoIncr,
+		Nullable: column.Nullable,
+		SQLType:  column.sqlType,
+	}
+}
+
+func boundKeyInfos(keys []*Key) []BoundKeyInfo {
+	infos := make([]BoundKeyInfo, len(keys))
+	for i, key := range keys {
+		infos[i] = boundKeyInfo(key)
+	}
+	return infos
+}
+
+func boundKeyInfo(key *Key) BoundKeyInfo {
+	if key == nil {
+		return BoundKeyInfo{}
+	}
+	info := BoundKeyInfo{
+		Name:    key.Name,
+		Primary: key.Primary,
+		Unique:  key.Unique,
+		Columns: make([]string, len(key.Columns)),
+	}
+	for i, column := range key.Columns {
+		if column != nil {
+			info.Columns[i] = column.Name
+		}
+	}
+	return info
+}


### PR DESCRIPTION
## What changed

- Add `DB.BoundModels()` to expose read-only snapshots of bound model metadata for a datasource.
- Add value-only metadata structs for bound models, mapped columns, and keys/indexes.
- Include copied mapped column details such as `AutoIncr`, `Nullable`, and `SQLType`.
- Add unit coverage for metadata contents and slice-copy behavior.

## Validation

- `go test -vet=off ./... -count=1`

Note: plain `go test ./... -run TestDBBoundModelsReturnsReadOnlyMetadata -count=1` is blocked by an existing vet issue in `builder_test.go`: `ExampleTable_Join refers to unknown field or method: Table.Join`.